### PR TITLE
Force loading vboxsf module so virtualbox shared folders work again.

### DIFF
--- a/scripts/base/vmtools.sh
+++ b/scripts/base/vmtools.sh
@@ -19,6 +19,7 @@ case "$PACKER_BUILDER_TYPE" in
       virtualbox-guest-tools \
       virtualbox-guest-x11 \
       virtualbox-guest-kmp-default
+    echo vboxsf >/etc/modules-load.d/vboxsf.conf
     ;;
 esac
 


### PR DESCRIPTION
Fixes openSUSE#2
