### PR TITLE
add vagrant group

### DIFF
--- a/http/13.1-general.xml
+++ b/http/13.1-general.xml
@@ -176,6 +176,16 @@
     </chroot-scripts>
   </scripts>
 
+  <groups config:type="list">
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>1000</gid>
+      <group_password>x</group_password>
+      <groupname>vagrant</groupname>
+      <userlist>vagrant</userlist>
+    </group>
+  </groups>
+
   <users config:type="list">
     <user>
       <username>root</username>

--- a/http/13.1-libvirt.xml
+++ b/http/13.1-libvirt.xml
@@ -176,6 +176,16 @@
     </chroot-scripts>
   </scripts>
 
+  <groups config:type="list">
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>1000</gid>
+      <group_password>x</group_password>
+      <groupname>vagrant</groupname>
+      <userlist>vagrant</userlist>
+    </group>
+  </groups>
+
   <users config:type="list">
     <user>
       <username>root</username>

--- a/http/13.2-general.xml
+++ b/http/13.2-general.xml
@@ -175,6 +175,16 @@
     </chroot-scripts>
   </scripts>
 
+  <groups config:type="list">
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>1000</gid>
+      <group_password>x</group_password>
+      <groupname>vagrant</groupname>
+      <userlist>vagrant</userlist>
+    </group>
+  </groups>
+
   <users config:type="list">
     <user>
       <username>root</username>

--- a/http/13.2-libvirt.xml
+++ b/http/13.2-libvirt.xml
@@ -175,6 +175,16 @@
     </chroot-scripts>
   </scripts>
 
+  <groups config:type="list">
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>1000</gid>
+      <group_password>x</group_password>
+      <groupname>vagrant</groupname>
+      <userlist>vagrant</userlist>
+    </group>
+  </groups>
+
   <users config:type="list">
     <user>
       <username>root</username>

--- a/http/42.1-general.xml
+++ b/http/42.1-general.xml
@@ -175,6 +175,16 @@
     </chroot-scripts>
   </scripts>
 
+  <groups config:type="list">
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>1000</gid>
+      <group_password>x</group_password>
+      <groupname>vagrant</groupname>
+      <userlist>vagrant</userlist>
+    </group>
+  </groups>
+
   <users config:type="list">
     <user>
       <username>root</username>

--- a/http/42.1-libvirt.xml
+++ b/http/42.1-libvirt.xml
@@ -175,6 +175,16 @@
     </chroot-scripts>
   </scripts>
 
+  <groups config:type="list">
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>1000</gid>
+      <group_password>x</group_password>
+      <groupname>vagrant</groupname>
+      <userlist>vagrant</userlist>
+    </group>
+  </groups>
+
   <users config:type="list">
     <user>
       <username>root</username>

--- a/http/tumbleweed-general.xml
+++ b/http/tumbleweed-general.xml
@@ -175,6 +175,16 @@
     </chroot-scripts>
   </scripts>
 
+  <groups config:type="list">
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>1000</gid>
+      <group_password>x</group_password>
+      <groupname>vagrant</groupname>
+      <userlist>vagrant</userlist>
+    </group>
+  </groups>
+
   <users config:type="list">
     <user>
       <username>root</username>

--- a/http/tumbleweed-libvirt.xml
+++ b/http/tumbleweed-libvirt.xml
@@ -175,6 +175,16 @@
     </chroot-scripts>
   </scripts>
 
+  <groups config:type="list">
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>1000</gid>
+      <group_password>x</group_password>
+      <groupname>vagrant</groupname>
+      <userlist>vagrant</userlist>
+    </group>
+  </groups>
+
   <users config:type="list">
     <user>
       <username>root</username>

--- a/scripts/base/vagrant.sh
+++ b/scripts/base/vagrant.sh
@@ -21,4 +21,7 @@ else
   echo "vagrant ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 fi
 
+groupadd vagrant
+usermod -aG vagrant vagrant
+
 exit 0

--- a/scripts/base/vagrant.sh
+++ b/scripts/base/vagrant.sh
@@ -21,7 +21,4 @@ else
   echo "vagrant ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 fi
 
-groupadd vagrant
-usermod -aG vagrant vagrant
-
 exit 0


### PR DESCRIPTION
vagrant use `vagrant:vagrant` permissions as default when using `rsync` as method for folder synch, however openSUSE vagrant box don't create this group - please see the test case below for the error. This patch creates missing vagrant group and add vagrant user as a member of the group.

### test case:

file structure
```
./Vagrantfile
./prov/file01.sh
```

```
$ cat Vagrantfile
```

```
# -*- mode: ruby -*-
# vi: set ft=ruby :

Vagrant.configure("2") do |config|

  config.vm.box = "opensuse/openSUSE-42.1-x86_64"

  config.vm.synced_folder "./prov", "/vagrant", type: "rsync", rsync__exclude: ".git/"

end
```


```
$ vagrant up
...
...
...
==> default: Rsyncing folder: /usr/home/adrian/suse-vagrant/test/prov/ =>/vagrant
==> default:   - Exclude: [".vagrant/", ".git/"]
The following SSH command responded with a non-zero exit status.
  Vagrant assumes that this means the command failed!

  find /vagrant -path /vagrant/.git/ -prune -o '!' -type l -a '(' ! -user vagrant -or ! -group vagrant ')' -exec chown vagrant:vagrant '{}' +

  Stdout from the command:



  Stderr from the command:

  find: warning: -path /vagrant/.git/ will not match anything because it ends with /.
  find: ‘vagrant’ is not the name of an existing group
  ```