### PR TITLE
Bump version to 1.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,6 @@ packer build -parallel=false \
   [x86_64](http://download.opensuse.org/vagrant/openSUSE-Tumbleweed-virtualbox-x86_64-1.0.1.box)
 * Libvirt/KVM
   [x86_64](http://download.opensuse.org/vagrant/openSUSE-Tumbleweed-libvirt-x86_64-1.0.1.box)
-* VMware
-  [x86_64](http://download.opensuse.org/vagrant/openSUSE-Tumbleweed-vmware-x86_64-1.0.1.box)
 * Also available at Atlas
   [x86_64](https://atlas.hashicorp.com/opensuse/boxes/openSUSE-Tumbleweed-x86_64)
 
@@ -37,13 +35,7 @@ packer build -parallel=false definitions/42.2-x86_64.json
 
 **Downloads**
 
-* Virtualbox
-  [x86_64](http://download.opensuse.org/vagrant/openSUSE-42.2-virtualbox-x86_64-1.0.1.box)
-* Libvirt/KVM
-  [x86_64](http://download.opensuse.org/vagrant/openSUSE-42.2-libvirt-x86_64-1.0.1.box)
-* VMware
-  [x86_64](http://download.opensuse.org/vagrant/openSUSE-42.2-vmware-x86_64-1.0.1.box)
-* Also available at Atlas
+* Available at Atlas
   [x86_64](https://atlas.hashicorp.com/opensuse/boxes/openSUSE-42.2-x86_64)
 
 

--- a/definitions/13.1-i586.json
+++ b/definitions/13.1-i586.json
@@ -1,6 +1,6 @@
 {
   "variables": {
-    "version": "1.0.1",
+    "version": "1.0.2",
     "os": "13.1",
     "arch": "i586",
 

--- a/definitions/13.1-x86_64.json
+++ b/definitions/13.1-x86_64.json
@@ -1,6 +1,6 @@
 {
   "variables": {
-    "version": "1.0.1",
+    "version": "1.0.2",
     "os": "13.1",
     "arch": "x86_64",
 

--- a/definitions/13.2-i586.json
+++ b/definitions/13.2-i586.json
@@ -1,6 +1,6 @@
 {
   "variables": {
-    "version": "1.0.1",
+    "version": "1.0.2",
     "os": "13.2",
     "arch": "i586",
 

--- a/definitions/13.2-x86_64.json
+++ b/definitions/13.2-x86_64.json
@@ -1,6 +1,6 @@
 {
   "variables": {
-    "version": "1.0.1",
+    "version": "1.0.2",
     "os": "13.2",
     "arch": "x86_64",
 

--- a/definitions/42.1-x86_64.json
+++ b/definitions/42.1-x86_64.json
@@ -1,6 +1,6 @@
 {
   "variables": {
-    "version": "1.0.1",
+    "version": "1.0.2",
     "os": "42.1",
     "arch": "x86_64",
 

--- a/definitions/42.2-x86_64.json
+++ b/definitions/42.2-x86_64.json
@@ -1,6 +1,6 @@
 {
   "variables": {
-    "version": "1.0.1",
+    "version": "1.0.2",
     "os": "42.2",
     "arch": "x86_64",
 

--- a/definitions/tumbleweed-x86_64.json
+++ b/definitions/tumbleweed-x86_64.json
@@ -1,6 +1,6 @@
 {
   "variables": {
-    "version": "1.0.1",
+    "version": "1.0.2",
     "os": "Tumbleweed",
     "arch": "x86_64",
 


### PR DESCRIPTION
Bump version to 1.0.2. This also update the README file to point
to the new boxes and drops VMware reference since we don't provide
such boxes for Tumbleweed and Leap 42.2