### PR TITLE
Increase image disk size

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ versions of openSUSE for running [Vagrant](https://www.vagrantup.com).
 
 ```bash
 packer build -parallel=false \
-  -var iso_url=http://download.opensuse.org/tumbleweed/iso/openSUSE-Tumbleweed-NET-x86_64-Snapshot20160529-Media.iso \
+  -var iso_url=http://download.opensuse.org/tumbleweed/iso/openSUSE-Tumbleweed-NET-x86_64-Snapshot201.0.39-Media.iso \
   -var iso_checksum=324a29b9e1cb5fd3f3fb92a65681939fff66ec6cd735aeff555a2bd7d4d495f0 \
   definitions/tumbleweed-x86_64.json
 ```

--- a/definitions/13.1-i586.json
+++ b/definitions/13.1-i586.json
@@ -1,6 +1,6 @@
 {
   "variables": {
-    "version": "1.0.2",
+    "version": "1.0.3",
     "os": "13.1",
     "arch": "i586",
 
@@ -38,7 +38,7 @@
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "1000s",
-      "disk_size": 20480,
+      "disk_size": 40960,
       "ssh_port": 22,
       "headless": false,
       "http_directory": "http",
@@ -74,7 +74,7 @@
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "1000s",
-      "disk_size": 20480,
+      "disk_size": 40960,
       "ssh_port": 22,
       "headless": false,
       "http_directory": "http",
@@ -114,7 +114,7 @@
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "1000s",
-      "disk_size": 20480,
+      "disk_size": 40960,
       "ssh_port": 22,
       "http_directory": "http",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -p",
@@ -153,7 +153,7 @@
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "60m",
-      "disk_size": 20480,
+      "disk_size": 40960,
       "ssh_port": 22,
       "headless": false,
       "http_directory": "http",

--- a/definitions/13.1-x86_64.json
+++ b/definitions/13.1-x86_64.json
@@ -1,6 +1,6 @@
 {
   "variables": {
-    "version": "1.0.2",
+    "version": "1.0.3",
     "os": "13.1",
     "arch": "x86_64",
 
@@ -38,7 +38,7 @@
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "1000s",
-      "disk_size": 20480,
+      "disk_size": 40960,
       "ssh_port": 22,
       "headless": false,
       "http_directory": "http",
@@ -74,7 +74,7 @@
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "1000s",
-      "disk_size": 20480,
+      "disk_size": 40960,
       "ssh_port": 22,
       "headless": false,
       "http_directory": "http",
@@ -114,7 +114,7 @@
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "1000s",
-      "disk_size": 20480,
+      "disk_size": 40960,
       "ssh_port": 22,
       "http_directory": "http",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -p",
@@ -153,7 +153,7 @@
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "60m",
-      "disk_size": 20480,
+      "disk_size": 40960,
       "ssh_port": 22,
       "headless": false,
       "http_directory": "http",

--- a/definitions/13.2-i586.json
+++ b/definitions/13.2-i586.json
@@ -1,6 +1,6 @@
 {
   "variables": {
-    "version": "1.0.2",
+    "version": "1.0.3",
     "os": "13.2",
     "arch": "i586",
 
@@ -38,7 +38,7 @@
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "1000s",
-      "disk_size": 20480,
+      "disk_size": 40960,
       "ssh_port": 22,
       "headless": false,
       "http_directory": "http",
@@ -74,7 +74,7 @@
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "1000s",
-      "disk_size": 20480,
+      "disk_size": 40960,
       "ssh_port": 22,
       "headless": false,
       "http_directory": "http",
@@ -118,7 +118,7 @@
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "1000s",
-      "disk_size": 20480,
+      "disk_size": 40960,
       "ssh_port": 22,
       "http_directory": "http",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -p",
@@ -157,7 +157,7 @@
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "60m",
-      "disk_size": 20480,
+      "disk_size": 40960,
       "ssh_port": 22,
       "headless": false,
       "http_directory": "http",

--- a/definitions/13.2-x86_64.json
+++ b/definitions/13.2-x86_64.json
@@ -1,6 +1,6 @@
 {
   "variables": {
-    "version": "1.0.2",
+    "version": "1.0.3",
     "os": "13.2",
     "arch": "x86_64",
 
@@ -38,7 +38,7 @@
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "1000s",
-      "disk_size": 20480,
+      "disk_size": 40960,
       "ssh_port": 22,
       "headless": false,
       "http_directory": "http",
@@ -74,7 +74,7 @@
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "1000s",
-      "disk_size": 20480,
+      "disk_size": 40960,
       "ssh_port": 22,
       "headless": false,
       "http_directory": "http",
@@ -118,7 +118,7 @@
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "1000s",
-      "disk_size": 20480,
+      "disk_size": 40960,
       "ssh_port": 22,
       "http_directory": "http",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -p",
@@ -157,7 +157,7 @@
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "60m",
-      "disk_size": 20480,
+      "disk_size": 40960,
       "ssh_port": 22,
       "headless": false,
       "http_directory": "http",

--- a/definitions/42.1-x86_64.json
+++ b/definitions/42.1-x86_64.json
@@ -1,6 +1,6 @@
 {
   "variables": {
-    "version": "1.0.2",
+    "version": "1.0.3",
     "os": "42.1",
     "arch": "x86_64",
 
@@ -38,7 +38,7 @@
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "1000s",
-      "disk_size": 20480,
+      "disk_size": 40960,
       "ssh_port": 22,
       "headless": false,
       "http_directory": "http",
@@ -74,7 +74,7 @@
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "1000s",
-      "disk_size": 20480,
+      "disk_size": 40960,
       "ssh_port": 22,
       "headless": false,
       "http_directory": "http",
@@ -118,7 +118,7 @@
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "1000s",
-      "disk_size": 20480,
+      "disk_size": 40960,
       "ssh_port": 22,
       "http_directory": "http",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -p",
@@ -157,7 +157,7 @@
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "60m",
-      "disk_size": 20480,
+      "disk_size": 40960,
       "ssh_port": 22,
       "headless": false,
       "http_directory": "http",

--- a/definitions/42.2-x86_64.json
+++ b/definitions/42.2-x86_64.json
@@ -1,6 +1,6 @@
 {
   "variables": {
-    "version": "1.0.2",
+    "version": "1.0.3",
     "os": "42.2",
     "arch": "x86_64",
 
@@ -38,7 +38,7 @@
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "60m",
-      "disk_size": 20480,
+      "disk_size": 40960,
       "ssh_port": 22,
       "headless": false,
       "http_directory": "http",
@@ -74,9 +74,9 @@
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "60m",
-      "disk_size": 20480,
+      "disk_size": 40960,
       "ssh_port": 22,
-      "headless": false,
+      "headless": true,
       "http_directory": "http",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -p",
       "boot_command": [
@@ -118,7 +118,7 @@
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "60m",
-      "disk_size": 20480,
+      "disk_size": 40960,
       "ssh_port": 22,
       "http_directory": "http",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -p",
@@ -157,7 +157,7 @@
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "60m",
-      "disk_size": 20480,
+      "disk_size": 40960,
       "ssh_port": 22,
       "headless": false,
       "http_directory": "http",

--- a/definitions/tumbleweed-x86_64.json
+++ b/definitions/tumbleweed-x86_64.json
@@ -1,10 +1,10 @@
 {
   "variables": {
-    "version": "1.0.2",
+    "version": "1.0.3",
     "os": "Tumbleweed",
     "arch": "x86_64",
 
-    "iso_url": "http://download.opensuse.org/tumbleweed/iso/openSUSE-Tumbleweed-NET-x86_64-Snapshot20160329-Media.iso",
+    "iso_url": "http://download.opensuse.org/tumbleweed/iso/openSUSE-Tumbleweed-NET-x86_64-Snapshot201.0.39-Media.iso",
     "iso_checksum": "802226e67f45d65ad0040d87a785b608011677d40f5109b158b63f8875a78c11",
     "iso_checksum_type": "sha256",
 
@@ -38,7 +38,7 @@
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "2h",
-      "disk_size": 20480,
+      "disk_size": 40960,
       "ssh_port": 22,
       "headless": false,
       "http_directory": "http",
@@ -74,7 +74,7 @@
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "2h",
-      "disk_size": 20480,
+      "disk_size": 40960,
       "ssh_port": 22,
       "headless": false,
       "http_directory": "http",
@@ -118,7 +118,7 @@
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "2h",
-      "disk_size": 20480,
+      "disk_size": 40960,
       "ssh_port": 22,
       "http_directory": "http",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -p",
@@ -157,7 +157,7 @@
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "2h",
-      "disk_size": 20480,
+      "disk_size": 40960,
       "ssh_port": 22,
       "headless": false,
       "http_directory": "http",


### PR DESCRIPTION
20GB disk size is to small for several uses that could benefit
from a standard Vagrant image provided by openSUSE.

- Increase image size to 40GB
- Bump version to 1.0.3