### PR TITLE
definitions: 42.2/Tumbleweed: Increase disk size to 40G

### DIFF
--- a/definitions/42.2-x86_64.json
+++ b/definitions/42.2-x86_64.json
@@ -38,7 +38,7 @@
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "60m",
-      "disk_size": 20480,
+      "disk_size": 40960,
       "ssh_port": 22,
       "headless": false,
       "http_directory": "http",

--- a/definitions/tumbleweed-x86_64.json
+++ b/definitions/tumbleweed-x86_64.json
@@ -38,7 +38,7 @@
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "2h",
-      "disk_size": 20480,
+      "disk_size": 40960,
       "ssh_port": 22,
       "headless": false,
       "http_directory": "http",


### PR DESCRIPTION
The vagrant images can be used as base VM systems to run automated
tests on them. Sometimes, 20G is not enough to accomondate all the
downloaded packages so we double the disk size. 20G is also pretty
low since the root filesystem is on btrfs which uses a lot of space
for housekeeping work.