### PR TITLE
http: 42.2/Tumbleweed: Use block device directly for swap

### DIFF
--- a/http/42.2-general.xml
+++ b/http/42.2-general.xml
@@ -10,7 +10,7 @@
 
   <bootloader>
     <global>
-      <append> resume=/dev/system/swap splash=silent quiet showopts</append>
+      <append> resume=/dev/sda1 splash=silent quiet showopts</append>
       <append_failsafe>showopts apm=off noresume edd=off powersaved=off nohz=off highres=off processor.max_cstate=1 nomodeset x11failsafe</append_failsafe>
       <default>openSUSE Leap 42.2</default>
       <distributor>openSUSE Leap 42.2</distributor>

--- a/http/42.2-libvirt.xml
+++ b/http/42.2-libvirt.xml
@@ -10,7 +10,7 @@
 
   <bootloader>
     <global>
-      <append> resume=/dev/system/swap splash=silent quiet showopts</append>
+      <append> resume=/dev/sda1 splash=silent quiet showopts</append>
       <append_failsafe>showopts apm=off noresume edd=off powersaved=off nohz=off highres=off processor.max_cstate=1 nomodeset x11failsafe</append_failsafe>
       <default>openSUSE Leap 42.2</default>
       <distributor>openSUSE Leap 42.2</distributor>

--- a/http/tumbleweed-general.xml
+++ b/http/tumbleweed-general.xml
@@ -10,7 +10,7 @@
 
   <bootloader>
     <global>
-      <append> resume=/dev/system/swap splash=silent quiet showopts</append>
+      <append> resume=/dev/sda1 splash=silent quiet showopts</append>
       <append_failsafe>showopts apm=off noresume edd=off powersaved=off nohz=off highres=off processor.max_cstate=1 nomodeset x11failsafe</append_failsafe>
       <default>openSUSE Tumbleweed</default>
       <distributor>openSUSE Tumbleweed</distributor>

--- a/http/tumbleweed-libvirt.xml
+++ b/http/tumbleweed-libvirt.xml
@@ -10,7 +10,7 @@
 
   <bootloader>
     <global>
-      <append> resume=/dev/system/swap splash=silent quiet showopts</append>
+      <append> resume=/dev/sda1 splash=silent quiet showopts</append>
       <append_failsafe>showopts apm=off noresume edd=off powersaved=off nohz=off highres=off processor.max_cstate=1 nomodeset x11failsafe</append_failsafe>
       <default>openSUSE Tumbleweed</default>
       <distributor>openSUSE Tumbleweed</distributor>


### PR DESCRIPTION
The default disk layout is using btrfs instead of LVM and as such
there is no /dev/systemd/swap anymore. We hardcode the value to
/dev/sda1 which normally points to the swap device.

Fixes #12