### PR TITLE
libvirt: Use vda instead of sda for swap device

### DIFF
--- a/http/42.2-libvirt.xml
+++ b/http/42.2-libvirt.xml
@@ -10,7 +10,7 @@
 
   <bootloader>
     <global>
-      <append> resume=/dev/sda1 splash=silent quiet showopts</append>
+      <append> resume=/dev/vda1 splash=silent quiet showopts</append>
       <append_failsafe>showopts apm=off noresume edd=off powersaved=off nohz=off highres=off processor.max_cstate=1 nomodeset x11failsafe</append_failsafe>
       <default>openSUSE Leap 42.2</default>
       <distributor>openSUSE Leap 42.2</distributor>

--- a/http/tumbleweed-libvirt.xml
+++ b/http/tumbleweed-libvirt.xml
@@ -10,7 +10,7 @@
 
   <bootloader>
     <global>
-      <append> resume=/dev/sda1 splash=silent quiet showopts</append>
+      <append> resume=/dev/vda1 splash=silent quiet showopts</append>
       <append_failsafe>showopts apm=off noresume edd=off powersaved=off nohz=off highres=off processor.max_cstate=1 nomodeset x11failsafe</append_failsafe>
       <default>openSUSE Tumbleweed</default>
       <distributor>openSUSE Tumbleweed</distributor>


### PR DESCRIPTION
Commit 8da7623735c5 ("http: 42.2/Tumbleweed: Use block device directly for swap")
fixed the autoyast files to use block devices instead of LVM ones but
the fix was not correct for libvirt since libvirt uses 'vda' instead of
'sda.

Fixes #12
Fixes: 8da7623735c5 ("http: 42.2/Tumbleweed: Use block device directly for swap")