### PR TITLE
scripts: base: base.sh: Only install required packages

### DIFF
--- a/scripts/base/base.sh
+++ b/scripts/base/base.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 set -x
 
-# Disable multiple kernel installs
-sed -i 's/^multiversion/# multiversion/' \
+# Disable multiple kernel installs and recommended packages
+sed -i -e 's/^multiversion/# multiversion/' \
+  -e s'/#\?[[:space:]]*solver.onlyRequires.*/solver.onlyRequires = true/' \
   /etc/zypp/zypp.conf
 
 exit 0


### PR DESCRIPTION
A 'zypper dup' on vagrant image leads to tons of packages being merged
because of the default 'solver.onlyRequires' option. The Vagrant images
are meant to be small and provide only what's absolutely necessary to
users so they can build on top of it. As such, lets just disable the
recommended packages by default.