### PR TITLE
scripts: base: cleanup.sh: Workaround bug for empty /etc/hosts

### DIFF
--- a/scripts/base/cleanup.sh
+++ b/scripts/base/cleanup.sh
@@ -39,4 +39,7 @@ EOF
 chmod a+x /etc/init.d/ssh_gen_host_keys
 chkconfig ssh_gen_host_keys on
 
+# bsc#1039656 Bring back the good /etc/hosts if Yast2 cleared it
+[[ -e /etc/hosts.YaST2save ]] && mv /etc/hosts.YaST2save /etc/hosts
+
 exit 0


### PR DESCRIPTION
If there is a hosts.Yast2save file then copy it back to /etc/hosts.
This workarounds bsc#1039656

Link: https://bugzilla.opensuse.org/show_bug.cgi?id=1039656