### PR TITLE
http: Disable installation of recommended packages

### DIFF
--- a/http/13.1-general.xml
+++ b/http/13.1-general.xml
@@ -103,7 +103,7 @@
 
   <software>
     <do_online_update config:type="boolean">false</do_online_update>
-    <install_recommended config:type="boolean">true</install_recommended>
+    <install_recommended config:type="boolean">false</install_recommended>
 
     <kernel>kernel-default</kernel>
 

--- a/http/13.1-libvirt.xml
+++ b/http/13.1-libvirt.xml
@@ -103,7 +103,7 @@
 
   <software>
     <do_online_update config:type="boolean">false</do_online_update>
-    <install_recommended config:type="boolean">true</install_recommended>
+    <install_recommended config:type="boolean">false</install_recommended>
 
     <kernel>kernel-default</kernel>
 

--- a/http/13.2-general.xml
+++ b/http/13.2-general.xml
@@ -103,7 +103,7 @@
 
   <software>
     <do_online_update config:type="boolean">false</do_online_update>
-    <install_recommended config:type="boolean">true</install_recommended>
+    <install_recommended config:type="boolean">false</install_recommended>
 
     <kernel>kernel-default</kernel>
 

--- a/http/13.2-libvirt.xml
+++ b/http/13.2-libvirt.xml
@@ -103,7 +103,7 @@
 
   <software>
     <do_online_update config:type="boolean">false</do_online_update>
-    <install_recommended config:type="boolean">true</install_recommended>
+    <install_recommended config:type="boolean">false</install_recommended>
 
     <kernel>kernel-default</kernel>
 

--- a/http/42.1-general.xml
+++ b/http/42.1-general.xml
@@ -103,7 +103,7 @@
 
   <software>
     <do_online_update config:type="boolean">false</do_online_update>
-    <install_recommended config:type="boolean">true</install_recommended>
+    <install_recommended config:type="boolean">false</install_recommended>
 
     <kernel>kernel-default</kernel>
 

--- a/http/42.1-libvirt.xml
+++ b/http/42.1-libvirt.xml
@@ -103,7 +103,7 @@
 
   <software>
     <do_online_update config:type="boolean">false</do_online_update>
-    <install_recommended config:type="boolean">true</install_recommended>
+    <install_recommended config:type="boolean">false</install_recommended>
 
     <kernel>kernel-default</kernel>
 

--- a/http/42.2-general.xml
+++ b/http/42.2-general.xml
@@ -103,7 +103,7 @@
 
   <software>
     <do_online_update config:type="boolean">false</do_online_update>
-    <install_recommended config:type="boolean">true</install_recommended>
+    <install_recommended config:type="boolean">false</install_recommended>
 
     <kernel>kernel-default</kernel>
 

--- a/http/42.2-libvirt.xml
+++ b/http/42.2-libvirt.xml
@@ -103,7 +103,7 @@
 
   <software>
     <do_online_update config:type="boolean">false</do_online_update>
-    <install_recommended config:type="boolean">true</install_recommended>
+    <install_recommended config:type="boolean">false</install_recommended>
 
     <kernel>kernel-default</kernel>
 

--- a/http/42.3-general.xml
+++ b/http/42.3-general.xml
@@ -103,7 +103,7 @@
 
   <software>
     <do_online_update config:type="boolean">false</do_online_update>
-    <install_recommended config:type="boolean">true</install_recommended>
+    <install_recommended config:type="boolean">false</install_recommended>
 
     <kernel>kernel-default</kernel>
 

--- a/http/42.3-libvirt.xml
+++ b/http/42.3-libvirt.xml
@@ -103,7 +103,7 @@
 
   <software>
     <do_online_update config:type="boolean">false</do_online_update>
-    <install_recommended config:type="boolean">true</install_recommended>
+    <install_recommended config:type="boolean">false</install_recommended>
 
     <kernel>kernel-default</kernel>
 

--- a/http/tumbleweed-general.xml
+++ b/http/tumbleweed-general.xml
@@ -103,7 +103,7 @@
 
   <software>
     <do_online_update config:type="boolean">false</do_online_update>
-    <install_recommended config:type="boolean">true</install_recommended>
+    <install_recommended config:type="boolean">false</install_recommended>
 
     <kernel>kernel-default</kernel>
 

--- a/http/tumbleweed-libvirt.xml
+++ b/http/tumbleweed-libvirt.xml
@@ -103,7 +103,7 @@
 
   <software>
     <do_online_update config:type="boolean">false</do_online_update>
-    <install_recommended config:type="boolean">true</install_recommended>
+    <install_recommended config:type="boolean">false</install_recommended>
 
     <kernel>kernel-default</kernel>
 


### PR DESCRIPTION
Installing the recommended packages by default has a significant
impact on the size of the image so do not pull them during installation.