### PR TITLE
42.3/tumbleweed: Install ca-certificates-mozilla and python-xml

### DIFF
--- a/http/42.3-general.xml
+++ b/http/42.3-general.xml
@@ -114,6 +114,7 @@
     </patterns>
 
     <packages config:type="list">
+      <package>ca-certificates-mozilla</package>
       <package>curl</package>
       <package>dhcp</package>
       <package>dhcp-client</package>
@@ -123,6 +124,7 @@
       <package>kernel-devel</package>
       <package>less</package>
       <package>make</package>
+      <package>python-xml</package>
       <package>sudo</package>
       <package>vim</package>
       <package>wget</package>

--- a/http/42.3-libvirt.xml
+++ b/http/42.3-libvirt.xml
@@ -114,6 +114,7 @@
     </patterns>
 
     <packages config:type="list">
+      <package>ca-certificates-mozilla</package>
       <package>curl</package>
       <package>dhcp</package>
       <package>dhcp-client</package>
@@ -123,6 +124,7 @@
       <package>kernel-devel</package>
       <package>less</package>
       <package>make</package>
+      <package>python-xml</package>
       <package>sudo</package>
       <package>vim</package>
       <package>wget</package>

--- a/http/tumbleweed-general.xml
+++ b/http/tumbleweed-general.xml
@@ -114,6 +114,7 @@
     </patterns>
 
     <packages config:type="list">
+      <package>ca-certificates-mozilla</package>
       <package>curl</package>
       <package>dhcp</package>
       <package>dhcp-client</package>
@@ -123,6 +124,7 @@
       <package>kernel-devel</package>
       <package>less</package>
       <package>make</package>
+      <package>python-xml</package>
       <package>sudo</package>
       <package>vim</package>
       <package>wget</package>

--- a/http/tumbleweed-libvirt.xml
+++ b/http/tumbleweed-libvirt.xml
@@ -114,6 +114,7 @@
     </patterns>
 
     <packages config:type="list">
+      <package>ca-certificates-mozilla</package>
       <package>curl</package>
       <package>dhcp</package>
       <package>dhcp-client</package>
@@ -123,6 +124,7 @@
       <package>kernel-devel</package>
       <package>less</package>
       <package>make</package>
+      <package>python-xml</package>
       <package>sudo</package>
       <package>vim</package>
       <package>wget</package>


### PR DESCRIPTION
Commit e8ae753e05a653c7a735f17254c970ce8c820e62 ("http: Disable
installation of recommended packages") disabled the installation of
recommended packages in order to make the images smaller. However,
some important packages like python-xml and ca-certificates-mozilla
are missing so add them to the list.