### PR TITLE
remove wicked cached files

### DIFF
--- a/scripts/base/cleanup.sh
+++ b/scripts/base/cleanup.sh
@@ -6,6 +6,9 @@ rm -rf /var/mail/* > /dev/null 2>&1
 rm -rf /var/lib/dhcp/* > /dev/null 2>&1
 rm -rf /etc/zypp/locks > /dev/null 2>&1
 
+# remove wicked xml to clean dhcp client id
+rm /var/lib/wicked/* > /dev/null 2>&1
+
 rm /etc/udev/rules.d/70-persistent-net.rules
 
 sed -i /HWADDR/d /etc/sysconfig/network/ifcfg-eth0


### PR DESCRIPTION
Wicked stores some of interface information, on the next boot that info picked up. Particularly DHCP client id. In case of multi machine setup they are all come up with same DHCP client id, and that confuse DHCP server, which response to each one with same IP address.