### PR TITLE
Autoyast: 15.0: Use a single btrfs partition

### DIFF
--- a/http/15.0-general.xml
+++ b/http/15.0-general.xml
@@ -72,6 +72,12 @@
       <device>/dev/sda</device>
       <initialize config:type="boolean">true</initialize>
       <use>all</use>
+      <partitions config:type="list">
+        <partition>
+          <filesystem config:type="symbol">btrfs</filesystem>
+          <mount>/</mount>
+        </partition>
+      </partitions>
     </drive>
   </partitioning>
 

--- a/http/15.0-libvirt.xml
+++ b/http/15.0-libvirt.xml
@@ -72,6 +72,12 @@
       <device>/dev/vda</device>
       <initialize config:type="boolean">true</initialize>
       <use>all</use>
+      <partitions config:type="list">
+        <partition>
+          <filesystem config:type="symbol">btrfs</filesystem>
+          <mount>/</mount>
+        </partition>
+      </partitions>
     </drive>
   </partitioning>
 


### PR DESCRIPTION
The automatic partition proposal was not so useful because it placed
/home at the end making it difficult to resize the root partition during
VM provisioning. It is much simpler to use a single btrfs partition for
everything.