### PR TITLE
Added I/O APIC

### DIFF
--- a/definitions/15.0-x86_64.json
+++ b/definitions/15.0-x86_64.json
@@ -33,7 +33,8 @@
 
       "vboxmanage": [
         ["modifyvm", "{{.Name}}", "--memory", "{{user `memory`}}"],
-        ["modifyvm", "{{.Name}}", "--cpus", "{{user `cpus`}}"]
+        ["modifyvm", "{{.Name}}", "--cpus", "{{user `cpus`}}"],
+        ["modifyvm", "{{.Name}}", "--ioapic", "on"]
       ],
 
       "output_directory": "images/openSUSE-{{user `os`}}-virtualbox-{{user `arch`}}-{{user `version`}}",


### PR DESCRIPTION
We need I/O APIC for setups with more than one cpu, otherwise the machine will crash with a kernel panic on startup.